### PR TITLE
Fix race condition NPE when using 3rd party pipes which tick before config is loaded

### DIFF
--- a/src/main/java/dev/rlnt/lazierae2/tile/base/ProcessorTile.java
+++ b/src/main/java/dev/rlnt/lazierae2/tile/base/ProcessorTile.java
@@ -582,6 +582,8 @@ public abstract class ProcessorTile<I extends AbstractItemHandler, R extends Abs
      */
     private int[] getSlotsForIOSide(IO_SIDE side) {
         IO_SETTING setting = sideConfig.get(side);
+        if (setting == null)
+            return new int[] {};
         switch (setting) {
             case NONE:
                 return new int[] {};


### PR DESCRIPTION
Fix race condition NPE when using 3rd party pipes which tick before config is loaded

## Issue Reference
Fixes Issue #14 

## Proposed Changes
- NPE due to race condition.

## Additional Context
A better fix would be not to offer the IItemHandler capability when getCapability is called if not ready to provide all parts of the interface at that time.
